### PR TITLE
Changed peer dependecy version on eslint-plugin-vue to one that exists.

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
   "peerDependencies": {
     "eslint": ">=5",
     "eslint-config-xo": "^0.26.0",
-    "eslint-plugin-vue": ">=7.12.3"
+    "eslint-plugin-vue": "^5.2.3"
   },
   "dependencies": {
     "eslint-plugin-unicorn": "^12.0.1",


### PR DESCRIPTION
Changed the peer dependency so it does not throw and error every time this package is installed.

Fixes issue #27 