### PR TITLE
feat(rules): update to eslint-plugin-vue version 6.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,14 +80,17 @@
     }
   },
   "config": {
-    "path": "./node_modules/cz-conventional-changelog"
+    "path": "./node_modules/cz-conventional-changelog",
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog"
+    }
   },
   "devDependencies": {
     "@semantic-release/changelog": "^3.0.2",
     "@semantic-release/git": "^7.0.8",
     "ava": "^2.0.0",
-    "cz-conventional-changelog": "^3.0.0",
     "commitizen": "^4.0.0",
+    "cz-conventional-changelog": "3.0.2",
     "nyc": "^14.1.1",
     "rimraf": "^3.0.0",
     "rollup": "^1.21.2",
@@ -102,7 +105,7 @@
   "peerDependencies": {
     "eslint": ">=5",
     "eslint-config-xo": "^0.26.0",
-    "eslint-plugin-vue": "^5.2.3"
+    "eslint-plugin-vue": "^6.0.1"
   },
   "dependencies": {
     "eslint-plugin-unicorn": "^13.0.0",

--- a/src/base.js
+++ b/src/base.js
@@ -16,10 +16,6 @@ module.exports = indent => {
 		},
 		plugins: ['vue'],
 		rules: {
-			// 'vue/no-deprecated-scope-attribute': 'warn',
-			// 'vue/keyword-spacing': xoConfigRules['keyword-spacing'],
-			// 'vue/dot-location': xoConfigRules['dot-location'],
-			// 'vue/no-empty-pattern': xoConfigRules['no-empty-pattern'],
 			'vue/attribute-hyphenation': ['error', 'always'],
 			'vue/attributes-order': 'warn',
 			'vue/block-spacing': 'warn',
@@ -32,6 +28,7 @@ module.exports = indent => {
 				'PascalCase',
 				{ registeredComponentsOnly: false }
 			],
+			'vue/dot-location': xoConfigRules['dot-location'],
 			'vue/eqeqeq': xoConfigRules.eqeqeq,
 			'vue/html-closing-bracket-newline': [
 				'error',
@@ -74,6 +71,7 @@ module.exports = indent => {
 			],
 			'vue/jsx-uses-vars': ['error'],
 			'vue/key-spacing': xoConfigRules['key-spacing'],
+			'vue/keyword-spacing': xoConfigRules['keyword-spacing'],
 			'vue/match-component-file-name': [
 				'error',
 				{
@@ -101,6 +99,8 @@ module.exports = indent => {
 			'vue/name-property-casing': ['error', 'PascalCase'],
 			'vue/no-async-in-computed-properties': ['error'],
 			'vue/no-boolean-default': ['error', 'no-default'],
+			'vue/no-deprecated-scope-attribute': 'warn',
+			'vue/no-empty-pattern': xoConfigRules['no-empty-pattern'],
 			'vue/no-use-v-if-with-v-for': [
 				'error',
 				{
@@ -210,6 +210,8 @@ module.exports = indent => {
 			'vue/valid-v-once': ['error'],
 			'vue/valid-v-pre': ['error'],
 			'vue/valid-v-show': ['error'],
+			'vue/valid-v-slot': ['error'],
+			'vue/v-slot-style': ['warn'],
 			'vue/valid-v-text': ['error'],
 			'import/no-unresolved': ['error']
 		}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1847,7 +1847,7 @@ cz-conventional-changelog@3.0.1:
   optionalDependencies:
     "@commitlint/load" ">6.1.1"
 
-cz-conventional-changelog@^3.0.0:
+cz-conventional-changelog@3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/cz-conventional-changelog/-/cz-conventional-changelog-3.0.2.tgz#f6b9a406177ab07f9a3a087e06103a045b376260"
   integrity sha512-MPxERbtQyVp0nnpCBiwzKGKmMBSswmCV3Jpef3Axqd5f3c/SOc6VFiSUlclOyZXBn3Xtf4snzt4O15hBTRb2gA==


### PR DESCRIPTION
Added vue/no-empty-pattern rule applies no-empty-pattern rule to expressions in <template>.
Added vue/dot-location rule applies dot-location rule to expressions in <template>.
Added vue/keyword-spacing rule applies keyword-spacing rule to expressions in <template>.
Added vue/no-deprecated-scope-attribute rule that reports deprecated scope attribute in Vue.js v2.5.0+.
Added vue/valid-v-slot rule that checks whether every v-slot directive is valid.
Added vue/v-slot-style rule that enforces v-slot directive style which you should use shorthand or long form.